### PR TITLE
Refactor Cpcdos C++ API for best lisibility.

### DIFF
--- a/OS2.2/API/gui/Textblock.cpp
+++ b/OS2.2/API/gui/Textblock.cpp
@@ -1,10 +1,10 @@
 #include <iostream>
-#include "../includes/CpcdosAPI.h"
+#include "../includes/CpcGuiAPI.h"
 
 #include "../../Cpcdos/include/sci.h"
 
 
-namespace CpcdosAPI {
+namespace CpcGuiAPI {
     Textblock::Textblock(   std::string text = "", 
                             std::tuple<int, int> pos = std::make_tuple(0, 0),
                             std::tuple<int, int> size = std::make_tuple(100, 100), 

--- a/OS2.2/API/gui/Window.cpp
+++ b/OS2.2/API/gui/Window.cpp
@@ -1,10 +1,10 @@
 #include <iostream>
-#include "../includes/CpcdosAPI.h"
+#include "../includes/CpcGuiAPI.h"
 
 #include "../../Cpcdos/include/sci.h"
 
 
-namespace CpcdosAPI {
+namespace CpcGuiAPI {
     Window::Window( std::string name = "Window", 
                     int type = 0, 
                     std::tuple<int, int> pos = std::make_tuple(0, 0),

--- a/OS2.2/API/includes/CpcGuiAPI.h
+++ b/OS2.2/API/includes/CpcGuiAPI.h
@@ -1,0 +1,89 @@
+#ifndef _CPCGUI_API_H_
+
+#include <tuple>
+#include <string>
+#include <iostream>
+#include <fstream>
+#include <cstring>
+#include <cstring>
+#include <cctype>
+// #include <unistd.h>
+#include <algorithm>
+
+
+/*
+==============================================
+=== CPCDOS C++ API
+=== WRITE BY CHRAPATI AND IPLUX
+==============================================
+=== CPCGUIAPI.H
+==============================================
+=== In this file, you can use GUI features
+=== in C++.
+==============================================
+=== NO WARANTY TO GET A STABLE PROGRAM DURING
+=== THE FIRST TRY!
+==============================================
+*/
+
+namespace CpcGuiAPI 
+{
+    // Coding style : plase use 'CpcdosAPI::component' in your code. Or you can use 'using namespace CpcdosAPI;'
+
+    class Window {
+    public:
+        std::string windowName;
+        int windowType; // Type of window (with/out titlebar, resizeable or not, etc.)
+        std::tuple<int, int> windowPos;
+        std::tuple<int, int> windowSize;
+        std::tuple<int, int, int, int> windowColor; // RGBA
+        std::tuple<int, int, int> windowTitleColor;
+        std::string windowSettings;
+        std::string windowHandle; // Use this variable for all of GUI components in your window. Reference in Cpcdos source-code.
+
+        Window(std::string name = "Window", 
+               int type = 0, 
+               std::tuple<int, int> pos = std::make_tuple(0, 0),
+               std::tuple<int, int> size = std::make_tuple(300, 200), 
+               std::tuple<int, int, int> wincol = std::make_tuple(255, 255, 255),
+               std::tuple<int, int, int> titlecol = std::make_tuple(100, 100, 100),
+               std::string sets = "",
+               std::string handle = "window"
+        ); // by default
+    };
+
+    class Textblock {
+    public:
+        std::string textblockText;
+        std::tuple<int, int> textblockPosition;
+        std::tuple<int, int> textblockSize;
+        std::tuple<int, int, int> textColor;
+        std::tuple<int, int, int> backgroundColor;
+        std::string textblockSettings;
+        Window parentWindow;
+        std::string textboxHandle;
+        
+        Textblock(std::string text = "", 
+                  std::tuple<int, int> pos = std::make_tuple(0, 0),
+                  std::tuple<int, int> size = std::make_tuple(100, 100), 
+                  std::tuple<int, int, int> textCol = std::make_tuple(255, 255, 255), 
+                  std::tuple<int, int, int> backCol = std::make_tuple(0, 0, 0), 
+                  std::string sets = "",
+                  Window parWin = nullptr, 
+                  std::string handle = "textblock"
+        );
+    };
+
+    class Picturebox {
+    public:
+        std::string pictureboxHandle;
+        std::string pictureboxFilePath;
+        std::tuple<int, int> pictureboxPosition;
+        std::tuple<int, int> pictureboxSize;
+        int pictureboxDisplayType;
+        Window parentWindow;
+    };
+}
+
+#endif
+

--- a/OS2.2/API/includes/CpcdosAPI.h
+++ b/OS2.2/API/includes/CpcdosAPI.h
@@ -13,62 +13,46 @@
 // #include <unistd.h>
 #include <algorithm>
 
-namespace CpcdosAPI {
-    class Window {
-    public:
-        std::string windowName;
-        int windowType;
-        std::tuple<int, int> windowPos;
-        std::tuple<int, int> windowSize;
-        std::tuple<int, int, int, int> windowColor; // RGBA
-        std::tuple<int, int, int> windowTitleColor;
-        std::string windowSettings;
-        std::string windowHandle;
+/*
+==============================================
+=== CPCDOS C++ API
+=== WRITE BY CHRAPATI AND IPLUX
+==============================================
+=== CPCDOSAPI.H
+==============================================
+=== In this file, we set a possibility
+=== to use Cpcdos OSx co-kernel features
+=== in C++ for ehanced developpers.
+==============================================
+=== NO WARANTY TO GET A STABLE PROGRAM DURING
+=== THE FIRST TRY!
+==============================================
+*/
 
-        Window(std::string name = "Window", 
-               int type = 0, 
-               std::tuple<int, int> pos = std::make_tuple(0, 0),
-               std::tuple<int, int> size = std::make_tuple(300, 200), 
-               std::tuple<int, int, int> wincol = std::make_tuple(255, 255, 255),
-               std::tuple<int, int, int> titlecol = std::make_tuple(100, 100, 100),
-               std::string sets = "",
-               std::string handle = "window"
-        );
-    };
-
-    class Textblock {
-    public:
-        std::string textblockText;
-        std::tuple<int, int> textblockPosition;
-        std::tuple<int, int> textblockSize;
-        std::tuple<int, int, int> textColor;
-        std::tuple<int, int, int> backgroundColor;
-        std::string textblockSettings;
-        Window parentWindow;
-        std::string textboxHandle;
-        
-        Textblock(std::string text = "", 
-                  std::tuple<int, int> pos = std::make_tuple(0, 0),
-                  std::tuple<int, int> size = std::make_tuple(100, 100), 
-                  std::tuple<int, int, int> textCol = std::make_tuple(255, 255, 255), 
-                  std::tuple<int, int, int> backCol = std::make_tuple(0, 0, 0), 
-                  std::string sets = "",
-                  Window parWin = nullptr, 
-                  std::string handle = "textblock"
-        );
-    };
-
-    class Picturebox {
-    public:
-        std::string pictureboxHandle;
-        std::string pictureboxFilePath;
-        std::tuple<int, int> pictureboxPosition;
-        std::tuple<int, int> pictureboxSize;
-        int pictureboxDisplayType;
-        Window parentWindow;
-    };
-
+namespace CpcdosAPI 
+{
+    // SHELL FUNCTIONS
     void terminal_print(std::string str);
+
+    // CPCDOS VARIABLES
+
+    // GETTERS
+    void get_cpuid();
+    void get_ram();
+    void get_hour();
+    void get_date();
+    void get_globalTime();
+    void get_processList();
+    void get_threadList();
+
+    // SETTERS
+    void set_activeOS(std::string active_os);
+    
+    // THREADS AND PROCESS
+
+    // CREATING
+    void create_newThread(std::string threadTID, std::string parent_process);
+    void create_newProcess(std::string processPID);
 }
 
 

--- a/OS2.2/API/includes/CpcdosAPI.h
+++ b/OS2.2/API/includes/CpcdosAPI.h
@@ -58,6 +58,16 @@ namespace CpcdosAPI {
         );
     };
 
+    class Picturebox {
+    public:
+        std::string pictureboxHandle;
+        std::string pictureboxFilePath;
+        std::tuple<int, int> pictureboxPosition;
+        std::tuple<int, int> pictureboxSize;
+        int pictureboxDisplayType;
+        Window parentWindow;
+    };
+
     void terminal_print(std::string str);
 }
 

--- a/OS2.2/API/main.cpp
+++ b/OS2.2/API/main.cpp
@@ -1,9 +1,11 @@
-#include "includes/CpcdosAPI.h"
-
+// #include "includes/CpcdosAPI.h"
+// 
 // myThing => variable
 // my_thing => function
 // MyThing => namespace
 
 
+
+// This is just an example.
 
 


### PR DESCRIPTION
I just dissociate Cpcdos GUI C++ conception and Cpcdos C++ global functions. Now, API have two headers : 

- **CpcdosAPI.h** : global functions for making Cpcdos distros and applications.
- **CpcGuiAPI.h** : GUI components classes for making graphical program. Can be associate with CpcdosAPI.h (logic btw).